### PR TITLE
[setup-fluent-validation] Leave Type Fluent Validator

### DIFF
--- a/src/Core/HR.LeaveManager.Application/Contracts/Exceptions/BadRequestException.cs
+++ b/src/Core/HR.LeaveManager.Application/Contracts/Exceptions/BadRequestException.cs
@@ -1,7 +1,19 @@
-﻿namespace HR.LeaveManager.Application.Contracts.Exceptions;
+﻿using FluentValidation.Results;
+
+namespace HR.LeaveManager.Application.Contracts.Exceptions;
 
 public class BadRequestException : Exception
 {
 	public BadRequestException(string message) : base(message)
 	{ }
+
+	public BadRequestException(string message, ValidationResult validationResult) : base(message)
+	{
+		foreach (var error in validationResult.Errors)
+		{
+			ValidationErrors.Add(error.ErrorMessage);
+		}
+	}
+
+	public List<string> ValidationErrors { get; set; } = new();
 }

--- a/src/Core/HR.LeaveManager.Application/Contracts/Persistence/ILeaveTypeRepository.cs
+++ b/src/Core/HR.LeaveManager.Application/Contracts/Persistence/ILeaveTypeRepository.cs
@@ -4,4 +4,5 @@ namespace HR.LeaveManager.Application.Contracts.Persistence;
 
 public interface ILeaveTypeRepository : IGenericRepository<LeaveType>
 {
+	Task<bool> IsLeaveTypeUnique(string name);
 }

--- a/src/Core/HR.LeaveManager.Application/Feature/LeaveType/Commands/CreateLeaveType/CreateLeaveTypeCommandHandler.cs
+++ b/src/Core/HR.LeaveManager.Application/Feature/LeaveType/Commands/CreateLeaveType/CreateLeaveTypeCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using HR.LeaveManager.Application.Contracts.Exceptions;
 using HR.LeaveManager.Application.Contracts.Persistence;
 using MediatR;
 
@@ -18,7 +19,11 @@ public class CreateLeaveTypeCommandHandler : IRequestHandler<CreateLeaveTypeComm
 	public async Task<int> Handle(CreateLeaveTypeCommand request, CancellationToken cancellationToken)
 	{
 		// Validate Incoming Data
+		var validator = new CreateLeaveTypeCommandValidator(_leaveTypeRepository);
+		var validatorResult = await validator.ValidateAsync(request);
 
+		if (!validatorResult.IsValid)
+			throw new BadRequestException("Invalid Leave Type", validatorResult);
 		// Convert to domain object
 		var leaveTypeCreated = _mapper.Map<LeaveManagement.Domain.LeaveType>(request);
 

--- a/src/Core/HR.LeaveManager.Application/Feature/LeaveType/Commands/CreateLeaveType/CreateLeaveTypeCommandValidator.cs
+++ b/src/Core/HR.LeaveManager.Application/Feature/LeaveType/Commands/CreateLeaveType/CreateLeaveTypeCommandValidator.cs
@@ -1,0 +1,29 @@
+﻿using FluentValidation;
+using HR.LeaveManager.Application.Contracts.Persistence;
+
+namespace HR.LeaveManager.Application.Feature.LeaveType.Commands.CreateLeaveType;
+
+public class CreateLeaveTypeCommandValidator : AbstractValidator<CreateLeaveTypeCommand>
+{
+	private readonly ILeaveTypeRepository _leaveTypeRepository;
+	public CreateLeaveTypeCommandValidator(ILeaveTypeRepository leaveTypeRepository)
+	{
+		RuleFor(x => x.Name)
+			.Empty().WithMessage("{PropertyName} is required")
+			.NotNull()
+			.MaximumLength(70).WithMessage("{PropertyName}  must be fewer than 70 characters");
+
+		RuleFor(x => x.DefaultDays)
+			.GreaterThan(100).WithMessage("{PropertyName} cannot exceed 100")
+			.LessThan(1).WithMessage("{PropertyName} cannot be less than 1");
+
+		RuleFor(q => q)
+			.MustAsync(LeaveTypeNameUnique)
+			.WithMessage("Leave Type allready exist");
+
+		_leaveTypeRepository = leaveTypeRepository;
+	}
+
+	private Task<bool> LeaveTypeNameUnique(CreateLeaveTypeCommand command, CancellationToken token)
+		=> _leaveTypeRepository.IsLeaveTypeUnique(command.Name);
+}

--- a/src/Core/HR.LeaveManager.Application/Feature/LeaveType/Commands/UpdateLeaveType/UpdateLeaveTypeCommandValidator.cs
+++ b/src/Core/HR.LeaveManager.Application/Feature/LeaveType/Commands/UpdateLeaveType/UpdateLeaveTypeCommandValidator.cs
@@ -1,0 +1,30 @@
+﻿using FluentValidation;
+using HR.LeaveManager.Application.Contracts.Persistence;
+
+namespace HR.LeaveManager.Application.Feature.LeaveType.Commands.UpdateLeaveType;
+
+public class UpdateLeaveTypeCommandValidator : AbstractValidator<UpdateLeaveTypeCommand>
+{
+	private readonly ILeaveTypeRepository _leaveTypeRepository;
+
+	public UpdateLeaveTypeCommandValidator(ILeaveTypeRepository leaveTypeRepository)
+	{
+		RuleFor(x => x.Name)
+			.Empty().WithMessage("{PropertyName} is required")
+			.NotNull()
+			.MaximumLength(70).WithMessage("{PropertyName}  must be fewer than 70 characters");
+
+		RuleFor(x => x.DefaultDays)
+			.GreaterThan(100).WithMessage("{PropertyName} cannot exceed 100")
+			.LessThan(1).WithMessage("{PropertyName} cannot be less than 1");
+
+		RuleFor(q => q)
+			.MustAsync(LeaveTypeNameUnique)
+			.WithMessage("Leave Type allready exist");
+
+		_leaveTypeRepository = leaveTypeRepository;
+	}
+
+	public Task<bool> LeaveTypeNameUnique(UpdateLeaveTypeCommand command, CancellationToken token)
+		=> _leaveTypeRepository.IsLeaveTypeUnique(command.Name);
+}

--- a/src/Core/HR.LeaveManager.Application/HR.LeaveManager.Application.csproj
+++ b/src/Core/HR.LeaveManager.Application/HR.LeaveManager.Application.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description
This PR introduces FluentValidation for validating LeaveType commands to ensure data consistency and prevent invalid inputs before processing. By using FluentValidation, we improve code maintainability, readability, and reusability.

## Changes Introduced
🔹 Added LeaveTypeCommandValidator using FluentValidation.
🔹 Implemented validation rules for properties such as:

1.  **Name:** _Required, maximum length of 70 characters_.

2. **DefaultDays**: _cannot exceed 100, cannot be less than 1_.

🔹 Integrated validator into the command handler.
🔹 Updated unit tests to cover validation scenarios.