### PR TITLE
[token-was-not-saved-in-local-storage] Missing Token in Local Storage

### DIFF
--- a/src/Infrastructure/HR.LeaveManagement.Identity/Services/AuthService.cs
+++ b/src/Infrastructure/HR.LeaveManagement.Identity/Services/AuthService.cs
@@ -73,7 +73,7 @@ public class AuthService : IAuthService
 				issuer: _jwtSettings.Issue,
 				audience: _jwtSettings.Audience,
 				claims: claims,
-				expires: DateTime.Now.AddMinutes(_jwtSettings.DurationInMinutes),
+				expires: DateTime.UtcNow.AddMinutes(_jwtSettings.DurationInMinutes),
 				signingCredentials: signinCredentials
 			);
 	}

--- a/src/UI/HR.LeaveManagement.UI.BlazorUI/Providers/ApiAuthenticationStateProvider.cs
+++ b/src/UI/HR.LeaveManagement.UI.BlazorUI/Providers/ApiAuthenticationStateProvider.cs
@@ -26,7 +26,7 @@ namespace HR.LeaveManagement.UI.BlazorUI.Providers
 			var savedToken = await _localStorageService.GetItemAsync<string>("token");
 			var tokenContent = _jwtSecurityTokenHandler.ReadJwtToken(savedToken);
 
-			if(tokenContent.ValidTo < DateTime.Now)
+			if(tokenContent.ValidTo < DateTime.UtcNow)
 			{
 				await _localStorageService.RemoveItemAsync("token");
 				return new AuthenticationState(user);


### PR DESCRIPTION
### Description:
- Please ensure this PR targets the **feature branch** (not `main`).

- Briefly describe what changes have been made in this PR.

### Problem:
There is one problem, after Login in, the JWT Token is not saved to the browser's local storage.

### Solution:
![jwt_token](https://github.com/user-attachments/assets/0837b400-a14d-4f1d-940c-7b2685283cae)

The JWT token expiration is stored as a Unix timestamp in UTC. (Image above)
When checking the expiration with DateTime.Now (which uses the local time zone), the token appears valid because the time zone offset (European time) adds 1 hour.
![create_jwt](https://github.com/user-attachments/assets/e5382722-bcc0-4962-a5d5-8ff1463f5d98)

Should be: expires: `DateTime.UtcNow.AddMinutes(_jwtSettings.DurationInMinutes),`
To fix this, it needs to be compared the token expiration time with DateTime.UtcNow and remove the token from local storage if it has expired.

![validate](https://github.com/user-attachments/assets/fc194f3d-2cf9-40cb-b8c1-4c428bfd560c)

My local time is UTC+1 during standard time (CET)

Example:
(CET): 19:10
UTC: 18:10
`If you give time 60min (1h) for expiration this will be 19:10 UTC and Date.Time.UtcNow will be 18:10
`
### Checklist:
- [x] I have selected the correct target branch.
- [x] I have run tests locally and they pass.
- [x] I have updated documentation if necessary.
- [x] I have ensured that the feature works correctly and no breaking changes exist.

### Related Issues (if applicable):
- Closes #<issue-number> (if your PR is related to an issue).

### Notes:
- Any additional context or instructions for reviewers.
